### PR TITLE
allow multiple spaces between alias and flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var execall = require('execall');
-var re = /^\s*[^$]\s*(?:-([a-z-]),\s+)?--([a-z-]+) +(.*)$/igm;
+var re = /^\s*[^$]\s*(?:-([a-z-]),[ \t]+)?--([a-z-]+) +(.*)$/igm;
 
 module.exports = function (str) {
 	var ret = {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var execall = require('execall');
-var re = /^\s*[^$]\s*(?:-([a-z-]), )?--([a-z-]+) +(.*)$/igm;
+var re = /^\s*[^$]\s*(?:-([a-z-]),\s+)?--([a-z-]+) +(.*)$/igm;
 
 module.exports = function (str) {
 	var ret = {

--- a/test.js
+++ b/test.js
@@ -6,10 +6,12 @@ const fixture = `
 	  $ unicorn <name>
 
 	Options
-	  --rainbow    Lorem ipsum dolor sit amet
-	  -m, --magic  Aenean commodo ligula eget dolor
-	  --pony       Nullam dictum felis eu pede
-	  -c, --color  Donec quam felis
+	  --rainbow     Lorem ipsum dolor sit amet
+	  -m, --magic   Aenean commodo ligula eget dolor
+	  --pony        Nullam dictum felis eu pede
+	  -c, --color   Donec quam felis
+	  -h,   --help  Felis quam cenod
+
 
 	Examples
 	  $ unicorn Peachy
@@ -18,9 +20,10 @@ const fixture = `
 
 test(t => {
 	const x = fn(fixture);
-	t.deepEqual(Object.keys(x.flags), ['rainbow', 'magic', 'pony', 'color']);
+	t.deepEqual(Object.keys(x.flags), ['rainbow', 'magic', 'pony', 'color', 'help']);
 	t.is(x.flags.rainbow.description, 'Lorem ipsum dolor sit amet');
 	t.is(x.flags.magic.alias, 'm');
 	t.is(x.aliases.m, 'magic');
 	t.is(x.aliases.c, 'color');
+	t.is(x.aliases.h, 'help');
 });


### PR DESCRIPTION
Hi Sindre,

Here's a little patch to parse alias / flags with help output like:

```
-h,   --help          # Print the generator's options and usage
```

I was trying to get options / arguments from yeoman generator's help output.

Thanks a lot for this little lib, simple but very useful.
